### PR TITLE
Fix pre-receive hook, arguments from stdin

### DIFF
--- a/git-hooks/pre-receive.d/php-syntax-check
+++ b/git-hooks/pre-receive.d/php-syntax-check
@@ -73,9 +73,11 @@ function parseCommit($oldrev, $newrev)
 
 // This pre-receive git hook gets passed the ref before the push, and the ref
 // that would be created if the push succeeds.
-$oldrev = $_SERVER['argv'][1];
-$newrev = $_SERVER['argv'][2];
-$refname = $_SERVER['argv'][3];
+$stdin = file_get_contents('php://stdin');
+$argv = explode(' ',$stdin);
+$oldrev =  $argv[0];
+$newrev =  $argv[1];
+$refname = $argv[2];
 
 parseCommit($oldrev, $newrev);
 


### PR DESCRIPTION
I tried that hook and it got php notices, resulting the "syntax checker hook mal functionning"

I fixed it by using "php://stdin" instead of $_SERVER['argv'] 

```
remote: PHP Notice:  Undefined offset: 1 in /home/michael/git/test/test-hooks/depot-bare.git/hooks/pre-receive on line 78
remote: PHP Notice:  Undefined offset: 2 in /home/michael/git/test/test-hooks/depot-bare.git/hooks/pre-receive on line 79
remote: PHP Notice:  Undefined offset: 3 in /home/michael/git/test/test-hooks/depot-bare.git/hooks/pre-receive on line 80
```
