### PR TITLE
Fixes to allow creation of the Docker image

### DIFF
--- a/README
+++ b/README
@@ -91,7 +91,7 @@ In case horde does not come up within reasonable time, you can run these command
 
 Check what's up
 
-docker compose logs horde_apache
+docker compose logs php-apache84
 
 dev-php84-ldap/00-prechecks.sh 
 ✅ Found GITHUB_TOKEN variable

--- a/dev-php84-ldap/composer.json.bundle
+++ b/dev-php84-ldap/composer.json.bundle
@@ -1,0 +1,46 @@
+{
+    "name": "horde/bundle",
+    "description": "A base project for a horde installation",
+    "type": "project",
+    "require": {
+        "composer-plugin-api": "^2.2",
+        "horde/horde-installer-plugin": "^3 || ^2.5.1 || dev-FRAMEWORK_6_0 || dev-master",
+        "horde/horde": "^6 || dev-FRAMEWORK_6_0",
+        "horde/routes": "^3 || dev-FRAMEWORK_6_0",
+        "horde/hordectl": "dev-FRAMEWORK_6_0",
+        "pear/console_color2": "^0.1.2",
+        "pear/console_table": "^1.3",
+        "horde/imp": "dev-FRAMEWORK_6_0",
+        "horde/kronolith": "dev-FRAMEWORK_6_0",
+        "horde/turba": "dev-FRAMEWORK_6_0",
+        "horde/nag": "dev-FRAMEWORK_6_0",
+        "horde/activesync": "dev-FRAMEWORK_6_0",
+        "horde/ingo": "dev-FRAMEWORK_6_0",
+        "horde/components": "dev-FRAMEWORK_6_0"
+    },
+    "require-dev": {
+        "horde/test": "dev-FRAMEWORK_6_0"
+    },
+    "license": "GPL-3.0-only",
+    "authors": [
+        {
+            "name": "Ralf Lang",
+            "email": "ralf.lang@ralf-lang.de"
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "extra": {
+        "installer-types": [
+            "horde-library",
+            "horde-application"
+        ]
+    },
+    "config": {
+        "allow-plugins": {
+            "horde/horde-installer-plugin": true
+        }
+    }
+}
+
+

--- a/dev-php84-ldap/images/php8.4-apache-horde/01-install-tools.sh
+++ b/dev-php84-ldap/images/php8.4-apache-horde/01-install-tools.sh
@@ -4,8 +4,9 @@ php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 php composer-setup.php
 php -r "unlink('composer-setup.php');"
 
-gh release download --clobber -R horde/components -p 'horde-components.phar' -D ./tools/
-gh release download --clobber -R phpstan/phpstan -p 'phpstan.phar' -D ./tools/
+# there was no 'latest' release entry so had to change it to a specific tag and file to make it work
+gh release download v1.0.0alpha37 --clobber -R horde/components -p 'horde-components-1.0.0-alpha37.phar' -O /usr/local/tools/horde-components.phar
+gh release download --clobber -R phpstan/phpstan -p 'phpstan.phar' -O /usr/local/tools/phpstan.phar
 wget -O /usr/local/tools/phive.phar "https://phar.io/releases/phive.phar" 
 wget -O /usr/local/tools/phpunit-12.phar https://phar.phpunit.de/phpunit-12.phar &> /dev/null
 echo "✅ Downloaded composer, horde-components, phpstan and phive"
@@ -14,5 +15,5 @@ wget -O /usr/local/tools/phpunit-10.phar https://phar.phpunit.de/phpunit-10.phar
 wget -O /usr/local/tools/phpunit-9.phar https://phar.phpunit.de/phpunit-9.phar   &> /dev/null
 echo "✅ Downloaded phpunit 12, 11, 10 and 9"
 chmod +x /usr/local/tools/*.phar
-cp -rs /usr/local/tools/* /usr/local/bin" &> /dev/null
+cp -rs /usr/local/tools/* /usr/local/bin &> /dev/null
 echo "✅ Linked all phar tools to /usr/local/bin"

--- a/dev-php84-ldap/images/php8.4-apache-horde/Dockerfile
+++ b/dev-php84-ldap/images/php8.4-apache-horde/Dockerfile
@@ -8,13 +8,13 @@ RUN apt-get update && apt-get install -y \
         libjpeg62-turbo-dev \
         libpng-dev \
         libldap2-dev \
-        git gh \
+        wget git gh \
         mc \
         vim \
         locales-all \
-        libicu72 libicu-dev \
-    && docker-php-ext-install gettext mysqli pdo pdo_mysql intl iconv ldap \
-    && docker-php-ext-enable gettext mysqli pdo pdo_mysql intl iconv ldap \
+        libicu76 libicu-dev \
+    && docker-php-ext-install gettext mysqli pdo pdo_mysql intl iconv bcmath ldap \
+    && docker-php-ext-enable gettext mysqli pdo pdo_mysql intl iconv bcmath ldap \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --chmod=775 --chown=root *.sh /usr/local/bin/


### PR DESCRIPTION
README:
 - fix: docker compose logs command requires a service name instead of the container name

images/php8.4-apache-horde/01-install-tools.sh:
 - fix: typo in command for making symlinks
 - fix: horde-components.phar has no 'latest' release, changed gh release command to include a specific tag and specific output file

images/php8.4-apache-horde/Dockerfile:
 - fix: libcu72 doesn't existin in debian trixie, changed to libcu76
 - fix: wget isn't available in trixie image, added to the inital apt commands
 - fix: bcmath extension required, added to docker-ext-install/enable

ADDED FILES
 - composer.json.bundle - this is needed for the composer install command to compleate in the install-tree